### PR TITLE
feat: `sendFile` implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,47 @@ For help getting started with Flutter development, view the
 [online documentation](https://flutter.dev/docs), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
 
+### File sending log example
+
+Here is a file sending log using one channel:
+
+```text
+# File chunks are sent sequentially.
+[Scheduler] Sending chunk n°0.
+[Scheduler] Sending chunk n°1.
+[Scheduler] Sending chunk n°2.
+[Scheduler] Sending chunk n°3.
+[Scheduler] Sending chunk n°4.
+[Scheduler] Sending chunk n°5.
+[Scheduler] Sending chunk n°6.
+[Scheduler] Sending chunk n°7.
+[Scheduler] Sending chunk n°8.
+
+# Some are acknowledged.
+[Scheduler] Chunk n°7 was acknowledged.
+[Scheduler] Chunk n°8 was acknowledged.
+[Scheduler] Chunk n°5 was acknowledged.
+
+# Some time out.
+[Scheduler] Chunk n°0 was not acknowledged in time, resending.
+[Scheduler] Chunk n°4 was acknowledged.
+[Scheduler] Chunk n°1 was not acknowledged in time, resending.
+[Scheduler] Chunk n°2 was not acknowledged in time, resending.
+[Scheduler] Chunk n°3 was not acknowledged in time, resending.
+[Scheduler] Chunk n°6 was not acknowledged in time, resending.
+
+# Chunks which timed out are sent anew.
+[Scheduler] Sending chunk n°6.
+[Scheduler] Sending chunk n°3.
+[Scheduler] Sending chunk n°2.
+[Scheduler] Sending chunk n°1.
+[Scheduler] Sending chunk n°0.
+[Scheduler] Chunk n°2 was acknowledged.
+[Scheduler] Chunk n°0 was acknowledged.
+[Scheduler] Chunk n°1 was acknowledged.
+[Scheduler] Chunk n°6 was acknowledged.
+[Scheduler] Chunk n°3 was acknowledged.
+
+# File sending ends when all chunks have been acknowledged.
+[Scheduler] Finished dispatching all chunks to channels.
+```

--- a/lib/channels/channel.dart
+++ b/lib/channels/channel.dart
@@ -6,8 +6,7 @@ typedef ChannelCallback = Function(ChannelEvent even, dynamic data);
 abstract class Channel {
   /// Provides information to the scheduler about what's happening in the
   /// current channel.
-  ChannelCallback on;
-  Channel({required this.on});
+  late ChannelCallback on;
 
   /// Initializes current channel, and returns when it is ready to send data.
   Future<void> init();

--- a/lib/channels/channel.dart
+++ b/lib/channels/channel.dart
@@ -13,5 +13,5 @@ abstract class Channel {
 
   /// Sends a file piece through current channel, and returns after successful
   /// sending; this doesn't check if chunk was received.
-  void sendChunk(FileChunk chunk);
+  Future<void> sendChunk(FileChunk chunk);
 }

--- a/lib/scheduler/file_chunk_send_state.dart
+++ b/lib/scheduler/file_chunk_send_state.dart
@@ -1,8 +1,0 @@
-import 'package:async/async.dart';
-import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
-
-class FileChunkSendState {
-  FileChunk data;
-  CancelableOperation resubmissionTimer;
-  FileChunkSendState({required this.data, required this.resubmissionTimer});
-}

--- a/lib/scheduler/file_chunk_send_state.dart
+++ b/lib/scheduler/file_chunk_send_state.dart
@@ -1,7 +1,8 @@
+import 'package:async/async.dart';
 import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
 
 class FileChunkSendState {
   FileChunk data;
-  Future timer;
-  FileChunkSendState({required this.data, required this.timer});
+  CancelableOperation resubmissionTimer;
+  FileChunkSendState({required this.data, required this.resubmissionTimer});
 }

--- a/lib/scheduler/file_chunk_send_state.dart
+++ b/lib/scheduler/file_chunk_send_state.dart
@@ -1,0 +1,7 @@
+import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
+
+class FileChunkSendState {
+  FileChunk data;
+  Future timer;
+  FileChunkSendState({required this.data, required this.timer});
+}

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -55,8 +55,18 @@ abstract class Scheduler {
     await sendChunks(chunksQueue, resubmissionTimers);
   }
 
+  /// This lets Scheduler instances implement their own chunks sending policy.
+  /// 
+  /// The implementation should send all chunks' content, by calling the 
+  /// sendChunk method; it can also check for any resubmission timer presence, 
+  /// to avoid finishing execution while some chunks have not been acknowledged.
   Future<void> sendChunks(List<FileChunk> chunks, Map<int, CancelableOperation> resubmissionTimers);
 
+  /// Sends a data chunk through a specified channel.
+  /// 
+  /// If such chunk is not acknowledged within a given duration, this will put
+  /// the chunk at the head of the sending queue, for it to be resent as soon
+  /// as possible.
   Future<void> sendChunk(FileChunk chunk, Channel channel) async {
     resubmissionTimers.putIfAbsent(
         chunk.identifier,

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -19,6 +19,13 @@ abstract class Scheduler {
     channels.add(channel);
   }
 
+  /// Sends file chunks through available channels.
+  ///
+  /// While there are chunks to send, it unstacks them one by one, and choose
+  /// a channel to send them.
+  ///
+  /// When sending a chunk, this registers a timeout callback, that triggers
+  /// resending chunk if channel didn't send an acknowledgement.
   Future<void> sendFile(File file, int chunksize) async {
     if (channels.isEmpty) {
       throw StateError('Cannot send file because scheduler has no channel.');

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:channel_multiplexed_scheduler/channels/channel_event.dart';
 import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
+import 'package:channel_multiplexed_scheduler/scheduler/file_chunk_send_state.dart';
 
 import '../channels/channel.dart';
 
@@ -10,6 +12,7 @@ import '../channels/channel.dart';
 abstract class Scheduler {
   late final List<Channel> channels = [];
   late List<FileChunk> chunksQueue = [];
+  final Map<int, FileChunkSendState> sendState = {};
 
   /// Adds a channel to be used to send file chunks.
   void useChannel(Channel channel) {
@@ -39,8 +42,6 @@ abstract class Scheduler {
     
     // open all channels
     Future.wait(channels.map((c) => c.init()));
-
-    // TODO create a map { int => {chunk, timeout} }
   }
 
   /// Divides an input file into chunks of *chunksize* size.

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -8,7 +8,7 @@ import '../channels/channel.dart';
 typedef FileChunks = Map<int, FileChunk>;
 
 abstract class Scheduler {
-  late List<Channel> channels;
+  late final List<Channel> channels = [];
 
   /// Adds a channel to be used to send file chunks.
   void useChannel(Channel channel) {

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -50,12 +50,12 @@ abstract class Scheduler {
     Future.wait(channels.map((c) => c.init()));
 
     // Begin sending chunks.
-    sendChunks(chunksQueue, resubmissionTimers);
+    await sendChunks(chunksQueue, resubmissionTimers);
   }
 
   Future<void> sendChunks(List<FileChunk> chunks, Map<int, CancelableOperation> resubmissionTimers);
 
-  void sendChunk(FileChunk chunk, Channel channel) {
+  Future<void> sendChunk(FileChunk chunk, Channel channel) async {
     resubmissionTimers.putIfAbsent(
         chunk.identifier,
             () => CancelableOperation.fromFuture(
@@ -66,7 +66,7 @@ abstract class Scheduler {
         )
     );
     debugPrint("[Scheduler] Sending chunk n°${chunk.identifier}.");
-    channel.sendChunk(chunk);
+    await channel.sendChunk(chunk);
   }
 
   /// Divides an input file into chunks of *chunksize* size.

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:channel_multiplexed_scheduler/channels/channel_event.dart';
 import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
 
 import '../channels/channel.dart';
@@ -21,6 +22,20 @@ abstract class Scheduler {
     }
 
     FileChunks chunks = splitFile(file, chunksize);
+
+    // initialize channels event listeners
+    for (var channel in channels) {
+      channel.on = (ChannelEvent event, dynamic data) {
+        switch (event) {
+          case ChannelEvent.acknowledgment:
+            // TODO: Handle this case.
+            break;
+          case ChannelEvent.opened:
+            // TODO: Handle this case.
+            break;
+        }
+      };
+    }
     
     // open all channels
     Future.wait(channels.map((c) => c.init()));

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -39,6 +39,8 @@ abstract class Scheduler {
     
     // open all channels
     Future.wait(channels.map((c) => c.init()));
+
+    // TODO create a map { int => {chunk, timeout} }
   }
 
   /// Divides an input file into chunks of *chunksize* size.

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -8,11 +8,11 @@ import '../channels/channel.dart';
 typedef FileChunks = Map<int, FileChunk>;
 
 abstract class Scheduler {
-  late List<Channel> _channels;
+  late List<Channel> channels;
 
   /// Adds a channel to be used to send file chunks.
   void useChannel(Channel channel) {
-    _channels.add(channel);
+    channels.add(channel);
   }
 
   Future<void> sendFile(File file, int chunksize) async {

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:async/async.dart';
 import 'package:channel_multiplexed_scheduler/channels/channel_event.dart';
 import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
+import 'package:flutter/material.dart';
 
 import '../channels/channel.dart';
 
@@ -21,6 +22,7 @@ abstract class Scheduler {
       switch (event) {
         case ChannelEvent.acknowledgment:
           int chunkId = data;
+          debugPrint('[Scheduler] Received ACK for chunk n°$chunkId.');
           CancelableOperation timer = resubmissionTimers.remove(chunkId)!;
           timer.cancel();
           break;
@@ -63,6 +65,7 @@ abstract class Scheduler {
             })
         )
     );
+    debugPrint("[Scheduler] Sending chunk n°${chunk.identifier}.");
     channel.sendChunk(chunk);
   }
 

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -52,15 +52,11 @@ abstract class Scheduler {
     // Open all channels.
     Future.wait(channels.map((c) => c.init()));
 
-    // Stupid dummy implementation using only one channel.
-    while (chunksQueue.isNotEmpty || resubmissionTimers.isNotEmpty) {
-      if (chunksQueue.isEmpty) {
-        sleep(const Duration(milliseconds: 200));
-      } else {
-        sendChunk(chunksQueue.removeAt(0), channels[0]);
-      }
-    }
+    // Begin sending chunks.
+    sendChunks(chunksQueue, resubmissionTimers);
   }
+
+  Future<void> sendChunks(List<FileChunk> chunks, Map<int, CancelableOperation> resubmissionTimers);
 
   void sendChunk(FileChunk chunk, Channel channel) {
     channel.sendChunk(chunk);

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -9,6 +9,7 @@ import '../channels/channel.dart';
 
 abstract class Scheduler {
   late final List<Channel> channels = [];
+  late List<FileChunk> chunksQueue = [];
 
   /// Adds a channel to be used to send file chunks.
   void useChannel(Channel channel) {
@@ -20,7 +21,7 @@ abstract class Scheduler {
       throw StateError('Cannot send file because scheduler has no channel.');
     }
 
-    List<FileChunk> chunks = splitFile(file, chunksize);
+    chunksQueue = splitFile(file, chunksize);
 
     // initialize channels event listeners
     for (var channel in channels) {

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -57,20 +57,22 @@ abstract class Scheduler {
       if (chunksQueue.isEmpty) {
         sleep(const Duration(milliseconds: 200));
       } else {
-        FileChunk toSend = chunksQueue.removeAt(0);
-        channels[0].sendChunk(toSend);
-
-        resubmissionTimers.putIfAbsent(
-            toSend.identifier,
-            () => CancelableOperation.fromFuture(
-                Future.delayed(const Duration(seconds: 1), () {
-                  resubmissionTimers.remove(toSend.identifier);
-                  chunksQueue.insert(0, toSend);
-                })
-            )
-        );
+        sendChunk(chunksQueue.removeAt(0), channels[0]);
       }
     }
+  }
+
+  void sendChunk(FileChunk chunk, Channel channel) {
+    channel.sendChunk(chunk);
+    resubmissionTimers.putIfAbsent(
+        chunk.identifier,
+            () => CancelableOperation.fromFuture(
+            Future.delayed(const Duration(seconds: 1), () {
+              resubmissionTimers.remove(chunk.identifier);
+              chunksQueue.insert(0, chunk);
+            })
+        )
+    );
   }
 
   /// Divides an input file into chunks of *chunksize* size.

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -19,9 +19,11 @@ abstract class Scheduler {
     if (channels.isEmpty) {
       throw StateError('Cannot send file because scheduler has no channel.');
     }
-    
+
     FileChunks chunks = splitFile(file, chunksize);
-    // TODO send
+    
+    // open all channels
+    Future.wait(channels.map((c) => c.init()));
   }
 
   /// Divides an input file into chunks of *chunksize* size.

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -6,7 +6,6 @@ import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
 
 import '../channels/channel.dart';
 
-typedef FileChunks = Map<int, FileChunk>;
 
 abstract class Scheduler {
   late final List<Channel> channels = [];
@@ -21,7 +20,7 @@ abstract class Scheduler {
       throw StateError('Cannot send file because scheduler has no channel.');
     }
 
-    FileChunks chunks = splitFile(file, chunksize);
+    List<FileChunk> chunks = splitFile(file, chunksize);
 
     // initialize channels event listeners
     for (var channel in channels) {
@@ -46,13 +45,13 @@ abstract class Scheduler {
   /// Divides an input file into chunks of *chunksize* size.
   /// This will fail if input file is not accessible, or if input chunk size is
   /// invalid.
-  FileChunks splitFile (File file, int chunksize) {
+  List<FileChunk> splitFile (File file, int chunksize) {
     if (!file.existsSync()) {
       throw RangeError('Invalid input file (path="${file.path}").');
     }
 
     Uint8List bytes = file.readAsBytesSync();
-    FileChunks chunks = {};
+    List<FileChunk> chunks = [];
     int bytesCount = bytes.length;
     int index = 0;
 
@@ -61,7 +60,7 @@ abstract class Scheduler {
     }
 
     for (int i=0; i<bytesCount; i += chunksize) {
-      chunks.putIfAbsent(index, () => FileChunk(
+      chunks.add(FileChunk(
           identifier: index,
           data: bytes.sublist(i, i + chunksize > bytesCount
               ? bytesCount

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -59,7 +59,6 @@ abstract class Scheduler {
   Future<void> sendChunks(List<FileChunk> chunks, Map<int, CancelableOperation> resubmissionTimers);
 
   void sendChunk(FileChunk chunk, Channel channel) {
-    channel.sendChunk(chunk);
     resubmissionTimers.putIfAbsent(
         chunk.identifier,
             () => CancelableOperation.fromFuture(
@@ -69,6 +68,7 @@ abstract class Scheduler {
             })
         )
     );
+    channel.sendChunk(chunk);
   }
 
   /// Divides an input file into chunks of *chunksize* size.

--- a/lib/scheduler/scheduler.dart
+++ b/lib/scheduler/scheduler.dart
@@ -16,6 +16,10 @@ abstract class Scheduler {
   }
 
   Future<void> sendFile(File file, int chunksize) async {
+    if (channels.isEmpty) {
+      throw StateError('Cannot send file because scheduler has no channel.');
+    }
+    
     FileChunks chunks = splitFile(file, chunksize);
     // TODO send
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ">=2.5.0"
 
 dependencies:
+  async: ^2.8.2
   flutter:
     sdk: flutter
 

--- a/test/mock/channel/mock_channel.dart
+++ b/test/mock/channel/mock_channel.dart
@@ -1,0 +1,26 @@
+import 'dart:math';
+
+import 'package:channel_multiplexed_scheduler/channels/channel.dart';
+import 'package:channel_multiplexed_scheduler/channels/channel_event.dart';
+import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
+
+
+class MockChannel extends Channel {
+  bool isInit = false;
+  List<int> sentChunksIds = [];
+
+  @override
+  Future<void> init() async {
+    isInit = true;
+  }
+
+  @override
+  Future<void> sendChunk(FileChunk chunk) async {
+    await Future.delayed(Duration(milliseconds: Random().nextInt(2000)), () {
+      if (!sentChunksIds.contains(chunk.identifier)) {
+        sentChunksIds.add(chunk.identifier);
+      }
+      on(ChannelEvent.acknowledgment, chunk.identifier);
+    });
+  }
+}

--- a/test/mock/scheduler/mock_scheduler.dart
+++ b/test/mock/scheduler/mock_scheduler.dart
@@ -1,0 +1,22 @@
+import 'package:async/async.dart';
+import 'package:channel_multiplexed_scheduler/channels/channel.dart';
+import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
+import 'package:channel_multiplexed_scheduler/scheduler/scheduler.dart';
+import 'package:flutter/material.dart';
+
+
+class MockScheduler extends Scheduler {
+  // Stupid dummy implementation using only one channel.
+  @override
+  Future<void> sendChunks(List<FileChunk> chunks, List<Channel> channels, Map<int, CancelableOperation> resubmissionTimers) async {
+    while (chunks.isNotEmpty || resubmissionTimers.isNotEmpty) {
+      if (chunks.isEmpty) {
+        await Future.delayed(const Duration(milliseconds: 200));
+      } else {
+        sendChunk(chunks.removeAt(0), channels[0]);
+      }
+    }
+
+    debugPrint('[Scheduler] Finished dispatching all chunks to channels.');
+  }
+}

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -69,4 +69,13 @@ void main() {
               && e.message == 'Invalid input file (path="").')));
     });
   });
+
+
+  group('sendFile', () {
+    test('should throw when sending file with no channel', () {
+      expect(() async => await scheduler.sendFile(file, 100000),
+          throwsA(predicate((e) => e is RangeError
+              && e.message == 'Cannot send file because scheduler has no channel.')));
+    });
+  });
 }

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -36,8 +36,10 @@ class MockChannel extends Channel {
 
   @override
   Future<void> sendChunk(FileChunk chunk) async {
-    sentChunksIds.add(chunk.identifier);
     await Future.delayed(Duration(milliseconds: Random().nextInt(2000)), () {
+      if (!sentChunksIds.contains(chunk.identifier)) {
+        sentChunksIds.add(chunk.identifier);
+      }
       on(ChannelEvent.acknowledgment, chunk.identifier);
     });
   }

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -135,6 +135,9 @@ void main() {
 
       await scheduler.sendFile(file, 100000);
 
+      // chunks are not sent in order, so we need to sort their ids
+      channel1.sentChunksIds.sort((int a, int b) => a - b);
+
       expect(channel1.sentChunksIds, [0, 1, 2, 3, 4, 5, 6, 7, 8]);
       expect(channel2.sentChunksIds.isEmpty, true);
     });

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -1,49 +1,12 @@
 import 'dart:io';
-import 'dart:math';
 
-import 'package:async/src/cancelable_operation.dart';
-import 'package:channel_multiplexed_scheduler/channels/channel.dart';
-import 'package:channel_multiplexed_scheduler/channels/channel_event.dart';
 import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
 import 'package:channel_multiplexed_scheduler/scheduler/scheduler.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class MockScheduler extends Scheduler {
-  // Stupid dummy implementation using only one channel.
-  @override
-  Future<void> sendChunks(List<FileChunk> chunks, List<Channel> channels, Map<int, CancelableOperation> resubmissionTimers) async {
-    while (chunks.isNotEmpty || resubmissionTimers.isNotEmpty) {
-      if (chunks.isEmpty) {
-        await Future.delayed(const Duration(milliseconds: 200));
-      } else {
-        sendChunk(chunks.removeAt(0), channels[0]);
-      }
-    }
+import 'mock/channel/mock_channel.dart';
+import 'mock/scheduler/mock_scheduler.dart';
 
-    debugPrint('[Scheduler] Finished dispatching all chunks to channels.');
-  }
-}
-
-class MockChannel extends Channel {
-  bool isInit = false;
-  List<int> sentChunksIds = [];
-
-  @override
-  Future<void> init() async {
-    isInit = true;
-  }
-
-  @override
-  Future<void> sendChunk(FileChunk chunk) async {
-    await Future.delayed(Duration(milliseconds: Random().nextInt(2000)), () {
-      if (!sentChunksIds.contains(chunk.identifier)) {
-        sentChunksIds.add(chunk.identifier);
-      }
-      on(ChannelEvent.acknowledgment, chunk.identifier);
-    });
-  }
-}
 
 void main() {
   late File file;

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -118,5 +118,17 @@ void main() {
       expect(channel1.isInit, true);
       expect(channel2.isInit, true);
     });
+
+    test('should send all chunks through first channel with test strategy', () async {
+      MockChannel channel1 = MockChannel();
+      MockChannel channel2 = MockChannel();
+      scheduler.useChannel(channel1);
+      scheduler.useChannel(channel2);
+
+      await scheduler.sendFile(file, 100000);
+
+      expect(channel1.sentChunksIds, [0, 1, 2, 3, 4, 5, 6, 7, 8]);
+      expect(channel2.sentChunksIds.isEmpty, true);
+    });
   });
 }

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math';
 
 import 'package:async/src/cancelable_operation.dart';
 import 'package:channel_multiplexed_scheduler/channels/channel.dart';
@@ -12,11 +13,11 @@ class MockScheduler extends Scheduler {
   // Stupid dummy implementation using only one channel.
   @override
   Future<void> sendChunks(List<FileChunk> chunks, Map<int, CancelableOperation> resubmissionTimers) async {
-    while (chunksQueue.isNotEmpty || resubmissionTimers.isNotEmpty) {
-      if (chunksQueue.isEmpty) {
-        sleep(const Duration(milliseconds: 200));
+    while (chunks.isNotEmpty || resubmissionTimers.isNotEmpty) {
+      if (chunks.isEmpty) {
+        await Future.delayed(const Duration(milliseconds: 200));
       } else {
-        sendChunk(chunksQueue.removeAt(0), channels[0]);
+        sendChunk(chunks.removeAt(0), channels[0]);
       }
     }
 
@@ -36,7 +37,9 @@ class MockChannel extends Channel {
   @override
   Future<void> sendChunk(FileChunk chunk) async {
     sentChunksIds.add(chunk.identifier);
-    on(ChannelEvent.acknowledgment, chunk.identifier);
+    await Future.delayed(Duration(milliseconds: Random().nextInt(2000)), () {
+      on(ChannelEvent.acknowledgment, chunk.identifier);
+    });
   }
 }
 

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -23,16 +23,14 @@ void main() {
   group('splitFile', () {
     test("should split file into chunks", () {
       int chunksize = 1000;
-      
-      FileChunks chunks = scheduler.splitFile(file, chunksize);
-      expect(chunks.length, (fileLength/chunksize).ceil());
 
-      List<FileChunk> chunksList = chunks.values.toList();
-      FileChunk lastChunk = chunksList.removeLast();
+      List<FileChunk> chunks = scheduler.splitFile(file, chunksize);
+      expect(chunks.length, (fileLength/chunksize).ceil());
+      FileChunk lastChunk = chunks.removeLast();
 
       // all chunks should have same size,
       // except the last one which might be smaller
-      for (var chunk in chunksList) {
+      for (var chunk in chunks) {
         expect(chunk.data.length, chunksize);
       }
       expect(lastChunk.data.length <= chunksize, true);
@@ -59,8 +57,8 @@ void main() {
     });
 
     test("should split file in as many chunks as file bytes", () {
-      FileChunks chunks = scheduler.splitFile(file, 1);
-      expect(chunks.values.length, file.lengthSync());
+      List<FileChunk> chunks = scheduler.splitFile(file, 1);
+      expect(chunks.length, file.lengthSync());
     });
 
     test("should throw with non-existing file", () {

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:async/src/cancelable_operation.dart';
 import 'package:channel_multiplexed_scheduler/channels/channel.dart';
+import 'package:channel_multiplexed_scheduler/channels/channel_event.dart';
 import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
 import 'package:channel_multiplexed_scheduler/scheduler/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -32,6 +33,7 @@ class MockChannel extends Channel {
   @override
   void sendChunk(FileChunk chunk) {
     sentChunksIds.add(chunk.identifier);
+    on(ChannelEvent.acknowledgment, chunk.identifier);
   }
 }
 

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -20,51 +20,53 @@ void main() {
   });
 
 
-  test("should split file into chunks", () {
-    int chunksize = 1000;
-    
-    FileChunks chunks = scheduler.splitFile(file, chunksize);
-    expect(chunks.length, (fileLength/chunksize).ceil());
+  group('splitFile', () {
+    test("should split file into chunks", () {
+      int chunksize = 1000;
+      
+      FileChunks chunks = scheduler.splitFile(file, chunksize);
+      expect(chunks.length, (fileLength/chunksize).ceil());
 
-    List<FileChunk> chunksList = chunks.values.toList();
-    FileChunk lastChunk = chunksList.removeLast();
+      List<FileChunk> chunksList = chunks.values.toList();
+      FileChunk lastChunk = chunksList.removeLast();
 
-    // all chunks should have same size,
-    // except the last one which might be smaller
-    for (var chunk in chunksList) {
-      expect(chunk.data.length, chunksize);
-    }
-    expect(lastChunk.data.length <= chunksize, true);
-  });
+      // all chunks should have same size,
+      // except the last one which might be smaller
+      for (var chunk in chunksList) {
+        expect(chunk.data.length, chunksize);
+      }
+      expect(lastChunk.data.length <= chunksize, true);
+    });
 
-  test("should not split file with negative chunk size", () {
-    expect(() => scheduler.splitFile(file, -42),
-        throwsA(predicate((e) => e is RangeError
-            && e.message == 'Invalid chunk size (was -42).')));
-  });
+    test("should not split file with negative chunk size", () {
+      expect(() => scheduler.splitFile(file, -42),
+          throwsA(predicate((e) => e is RangeError
+              && e.message == 'Invalid chunk size (was -42).')));
+    });
 
-  test("should not split file with empty chunk size", () {
-    expect(() => scheduler.splitFile(file, 0),
-        throwsA(predicate((e) => e is RangeError
-            && e.message == 'Invalid chunk size (was 0).')));
-  });
+    test("should not split file with empty chunk size", () {
+      expect(() => scheduler.splitFile(file, 0),
+          throwsA(predicate((e) => e is RangeError
+              && e.message == 'Invalid chunk size (was 0).')));
+    });
 
-  test("should not split file with chunk size bigger than file size", () {
-    int chunksize = fileLength + 42;
+    test("should not split file with chunk size bigger than file size", () {
+      int chunksize = fileLength + 42;
 
-    expect(() => scheduler.splitFile(file, chunksize),
-        throwsA(predicate((e) => e is RangeError
-            && e.message == 'Invalid chunk size (was $chunksize).')));
-  });
+      expect(() => scheduler.splitFile(file, chunksize),
+          throwsA(predicate((e) => e is RangeError
+              && e.message == 'Invalid chunk size (was $chunksize).')));
+    });
 
-  test("should split file in as many chunks as file bytes", () {
-    FileChunks chunks = scheduler.splitFile(file, 1);
-    expect(chunks.values.length, file.lengthSync());
-  });
+    test("should split file in as many chunks as file bytes", () {
+      FileChunks chunks = scheduler.splitFile(file, 1);
+      expect(chunks.values.length, file.lengthSync());
+    });
 
-  test("should throw with non-existing file", () {
-    expect(() => scheduler.splitFile(File(''), 1000),
-        throwsA(predicate((e) => e is RangeError
-            && e.message == 'Invalid input file (path="").')));
+    test("should throw with non-existing file", () {
+      expect(() => scheduler.splitFile(File(''), 1000),
+          throwsA(predicate((e) => e is RangeError
+              && e.message == 'Invalid input file (path="").')));
+    });
   });
 }

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -74,7 +74,7 @@ void main() {
   group('sendFile', () {
     test('should throw when sending file with no channel', () {
       expect(() async => await scheduler.sendFile(file, 100000),
-          throwsA(predicate((e) => e is RangeError
+          throwsA(predicate((e) => e is StateError
               && e.message == 'Cannot send file because scheduler has no channel.')));
     });
   });

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 class MockScheduler extends Scheduler {
   // Stupid dummy implementation using only one channel.
   @override
-  Future<void> sendChunks(List<FileChunk> chunks, Map<int, CancelableOperation> resubmissionTimers) async {
+  Future<void> sendChunks(List<FileChunk> chunks, List<Channel> channels, Map<int, CancelableOperation> resubmissionTimers) async {
     while (chunks.isNotEmpty || resubmissionTimers.isNotEmpty) {
       if (chunks.isEmpty) {
         await Future.delayed(const Duration(milliseconds: 200));

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -1,10 +1,23 @@
 import 'dart:io';
 
+import 'package:async/src/cancelable_operation.dart';
 import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
 import 'package:channel_multiplexed_scheduler/scheduler/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class MockScheduler extends Scheduler {}
+class MockScheduler extends Scheduler {
+  // Stupid dummy implementation using only one channel.
+  @override
+  Future<void> sendChunks(List<FileChunk> chunks, Map<int, CancelableOperation> resubmissionTimers) async {
+    while (chunksQueue.isNotEmpty || resubmissionTimers.isNotEmpty) {
+      if (chunksQueue.isEmpty) {
+        sleep(const Duration(milliseconds: 200));
+      } else {
+        sendChunk(chunksQueue.removeAt(0), channels[0]);
+      }
+    }
+  }
+}
 
 void main() {
   late File file;

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -5,6 +5,7 @@ import 'package:channel_multiplexed_scheduler/channels/channel.dart';
 import 'package:channel_multiplexed_scheduler/channels/channel_event.dart';
 import 'package:channel_multiplexed_scheduler/file/file_chunk.dart';
 import 'package:channel_multiplexed_scheduler/scheduler/scheduler.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class MockScheduler extends Scheduler {
@@ -18,6 +19,8 @@ class MockScheduler extends Scheduler {
         sendChunk(chunksQueue.removeAt(0), channels[0]);
       }
     }
+
+    debugPrint('[Scheduler] Finished dispatching all chunks to channels.');
   }
 }
 
@@ -31,7 +34,7 @@ class MockChannel extends Channel {
   }
 
   @override
-  void sendChunk(FileChunk chunk) {
+  Future<void> sendChunk(FileChunk chunk) async {
     sentChunksIds.add(chunk.identifier);
     on(ChannelEvent.acknowledgment, chunk.identifier);
   }

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -21,7 +21,6 @@ class MockScheduler extends Scheduler {
 }
 
 class MockChannel extends Channel {
-  MockChannel({required super.on});
   bool isInit = false;
   List<int> sentChunksIds = [];
 
@@ -107,8 +106,8 @@ void main() {
     });
 
     test('should init channels', () async {
-      MockChannel channel1 = MockChannel(on: (event, data){});
-      MockChannel channel2 = MockChannel(on: (event, data){});
+      MockChannel channel1 = MockChannel();
+      MockChannel channel2 = MockChannel();
       scheduler.useChannel(channel1);
       scheduler.useChannel(channel2);
 


### PR DESCRIPTION
The `sendFile` method opens all available channels, then proceeds to send file chunks.

Scheduler keeps track of all sent file chunks, and resend those who weren't acknowledged in time (implementation of [Selective-repeat ARQ algorithm](https://en.wikipedia.org/wiki/Selective_Repeat_ARQ)).

Channel selection policy must be supplied by `Scheduler` implementations.

This is tested using `Channel` and `Scheduler` mock implementations.